### PR TITLE
error when using lumen 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Huawei Cloud OBS storage for Laravel based on [artwl/laravel-filesystem-obs](htt
 $ composer require "artwl/laravel-filesystem-obs:v3.4.0"
 ```
 
+注：需要composer为2.0及以上版本
+
 # Configuration
 
 1. After installing the library, register the `Obs\ObsServiceProvider` in your `config/app.php` file:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![packagist](https://badgen.net/packagist/v/artwl/laravel-filesystem-obs?icon=github) ![](https://badgen.net/packagist/php/artwl/laravel-filesystem-obs) ![](https://badgen.net/packagist/name/artwl/laravel-filesystem-obs?icon=github) ![](https://badgen.net/packagist/license/artwl/laravel-filesystem-obs) 
+[![packagist](https://badgen.net/packagist/v/artwl/laravel-filesystem-obs?icon=github)](https://packagist.org/packages/artwl/laravel-filesystem-obs) [![](https://badgen.net/packagist/php/artwl/laravel-filesystem-obs)](https://packagist.org/packages/artwl/laravel-filesystem-obs) [![](https://badgen.net/packagist/name/artwl/laravel-filesystem-obs?icon=github)](https://packagist.org/packages/artwl/laravel-filesystem-obs) [![](https://badgen.net/packagist/license/artwl/laravel-filesystem-obs)](https://packagist.org/packages/artwl/laravel-filesystem-obs) 
 
 # Huawei Cloud OBS for Laravel
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Huawei Cloud OBS for Laravel
 
-[Huawei Cloud OBS](https://support.huaweicloud.com/devg-obs_php_sdk_doc_zh/zh-cn_topic_0132036136.html) storage for Laravel based on [artwl/laravel-filesystem-obs](https://github.com/artwl/laravel-filesystem-obs).
+Huawei Cloud OBS storage for Laravel based on [artwl/laravel-filesystem-obs](https://github.com/artwl/laravel-filesystem-obs).
 
 # Requirement
 
-- PHP >= 7.1.3
+- PHP >= 7.1.3 || PHP >= 8.0
 
 # Installation
 
 ```shell
-$ composer require "artwl/laravel-filesystem-obs:v3.3.0"
+$ composer require "artwl/laravel-filesystem-obs:v3.4.0"
 ```
 
 # Configuration

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![packagist](https://badgen.net/packagist/v/artwl/laravel-filesystem-obs?icon=github) ![](https://badgen.net/packagist/php/artwl/laravel-filesystem-obs) ![](https://badgen.net/packagist/name/artwl/laravel-filesystem-obs?icon=github) ![](https://badgen.net/packagist/license/artwl/laravel-filesystem-obs) 
+
 # Huawei Cloud OBS for Laravel
 
 Huawei Cloud OBS storage for Laravel based on [artwl/laravel-filesystem-obs](https://github.com/artwl/laravel-filesystem-obs).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 # Installation
 
 ```shell
-$ composer require "artwl/laravel-filesystem-obs" -vvv
+$ composer require "artwl/laravel-filesystem-obs:v3.3.0"
 ```
 
 # Configuration

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Huawei Cloud OBS for Laravel
 
-[Huawei Cloud OBS](https://support.huaweicloud.com/devg-obs_php_sdk_doc_zh/zh-cn_topic_0132036136.html) storage for Laravel based on [dscmall/laravel-filesystem-obs](https://github.com/dscmall/laravel-filesystem-obs).
-
-[大商创技术团队](http://www.dscmall.cn)
+[Huawei Cloud OBS](https://support.huaweicloud.com/devg-obs_php_sdk_doc_zh/zh-cn_topic_0132036136.html) storage for Laravel based on [artwl/laravel-filesystem-obs](https://github.com/artwl/laravel-filesystem-obs).
 
 # Requirement
 
@@ -11,7 +9,7 @@
 # Installation
 
 ```shell
-$ composer require "dscmall/laravel-filesystem-obs" -vvv
+$ composer require "artwl/laravel-filesystem-obs" -vvv
 ```
 
 # Configuration
@@ -37,8 +35,8 @@ $ composer require "dscmall/laravel-filesystem-obs" -vvv
             'key' => env('OBS_ACCESS_ID'), // <Your Huawei OBS AccessKeyId>
             'secret' => env('OBS_ACCESS_KEY'), // <Your Huawei OBS AccessKeySecret>
             'bucket' => env('OBS_BUCKET'), // <OBS bucket name>
-            'endpoint' => env('OBS_ENDPOINT'), // <the endpoint of OBS, E.g: (https:// or http://).obs.cn-east-2.myhuaweicloud.com | custom domain, E.g:img.abc.com> OBS 外网节点或自定义外部域名
-            'cdn_domain' => env('OBS_CDN_DOMAIN'), //<CDN domain, cdn域名> 如果isCName为true, getUrl会判断cdnDomain是否设定来决定返回的url，如果cdnDomain未设置，则使用endpoint来生成url，否则使用cdn
+            'endpoint' => env('OBS_ENDPOINT'), // <the endpoint of OBS, E.g: (https:// or http://).obs.cn-east-2.myhuaweicloud.com | custom domain, E.g:img.abc.com> OBS 澶栫綉鑺傜偣鎴栬嚜瀹氫箟澶栭儴鍩熷悕
+            'cdn_domain' => env('OBS_CDN_DOMAIN'), //<CDN domain, cdn鍩熷悕> 濡傛灉isCName涓簍rue, getUrl浼氬垽鏂璫dnDomain鏄惁璁惧畾鏉ュ喅瀹氳繑鍥炵殑url锛屽鏋渃dnDomain鏈缃紝鍒欎娇鐢╡ndpoint鏉ョ敓鎴恥rl锛屽惁鍒欎娇鐢╟dn
             'ssl_verify' => env('OBS_SSL_VERIFY'), // <true|false> true to use 'https://' and false to use 'http://'. default is false,
             'debug' => env('APP_DEBUG'), // <true|false>
         ],

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.1.3|^8.0"
+        "php": "^7.1.3 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,26 +1,18 @@
 {
     "name": "artwl/laravel-filesystem-obs",
     "description": "huawei cloud obs filesystem storage for laravel 5+",
-    "keywords": [
-        "huawei",
-        "obs",
-        "laravel",
-        "filesystems",
-        "storage"
-    ],
     "license": "MIT",
     "require": {
         "php": "^7.1.3 || ^8.0",
         "guzzlehttp/guzzle": "^6.5"
     },
+    "authors": [{  
+        "name": "artwl",  
+        "email": "artwl@outlook.com"  
+    }],
     "autoload": {
         "psr-4": {
-            "Obs\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Obs\\Test\\": "tests/"
+            "Obs\\": "src"
         }
     },
     "extra": {
@@ -30,10 +22,5 @@
             ]
         }
     },
-    "scripts": {
-        "test": "vendor/bin/phpunit"
-    },
-    "config": {
-        "sort-packages": true
-    }
+    "minimum-stability": "stable"
 }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.1.3|^9=^8.0"
+        "php": "^7.1.3|^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.1.3 || ^8.0"
+        "php": "^7.1.3 || ^8.0",
+        "guzzlehttp/guzzle": "^6.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "dscmall/laravel-filesystem-obs",
+    "name": "artwl/laravel-filesystem-obs",
     "description": "huawei cloud obs filesystem storage for laravel 5+",
     "keywords": [
         "huawei",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.0"
+        "php": "^7.1.3|^9=^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/ObsAdapter.php
+++ b/src/ObsAdapter.php
@@ -399,6 +399,14 @@ class ObsAdapter extends AbstractAdapter
             $result['size'] = $object['Size'];
             $result['bytes'] = $object['Size'];
         }
+        
+        if (isset($object['stream'])) {
+            $result['stream'] = $object['stream'];
+        }
+
+        if (isset($object['contents'])) {
+            $result['contents'] = $object['contents'];
+        }
 
         $type = (substr($result['path'], -1) === '/' ? 'dir' : 'file');
 


### PR DESCRIPTION
I couldn't use Lumen version 9 when I was using it, then I searched and it turned out that it wasn't compatible with version 3 of the league/flysystem library and I had to downgrade to version 1 and when I was using version 1 I was having problems with the error "Object of class League\\Flysystem\\Filesystem could not be converted to string"